### PR TITLE
Add theme toggle for manual dark mode

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,6 +78,7 @@ const t = i18n[lang];
           <a href={`/3d/${latestDate}/`}>{t.nav3d}</a>
           <a href={`/weekly/${currentWeek}/`}>{t.navWeekly}</a>
         </nav>
+        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
       </div>
       <p class="meta">{t.updated}: {updatedPretty}</p>
       <p class="meta">{t.stories}: {items.length} • {t.page} 1/{totalPages}</p>
@@ -95,5 +96,22 @@ const t = i18n[lang];
         </nav>
       )}
     </main>
+    <script>
+      const root = document.documentElement;
+      const btn = document.getElementById('theme-toggle');
+      if (localStorage.getItem('theme') === 'dark') {
+        root.setAttribute('data-theme', 'dark');
+      }
+      btn?.addEventListener('click', () => {
+        const isDark = root.getAttribute('data-theme') === 'dark';
+        if (isDark) {
+          root.removeAttribute('data-theme');
+          localStorage.setItem('theme', 'light');
+        } else {
+          root.setAttribute('data-theme', 'dark');
+          localStorage.setItem('theme', 'dark');
+        }
+      });
+    </script>
   </body>
 </html>

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -70,7 +70,10 @@ const t = i18n[lang];
   </head>
   <body>
     <header>
-      <h1><a href="/">Hacker News Digest</a></h1>
+      <div class="header-top">
+        <h1><a href="/">Hacker News Digest</a></h1>
+        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+      </div>
       <p class="meta">{t.updated}: {updatedPretty}</p>
       <p class="meta">{t.stories}: {allItems.length} • {t.page} {currentPage}/{totalPages}</p>
     </header>
@@ -88,5 +91,22 @@ const t = i18n[lang];
         </nav>
       )}
     </main>
+    <script>
+      const root = document.documentElement;
+      const btn = document.getElementById('theme-toggle');
+      if (localStorage.getItem('theme') === 'dark') {
+        root.setAttribute('data-theme', 'dark');
+      }
+      btn?.addEventListener('click', () => {
+        const isDark = root.getAttribute('data-theme') === 'dark';
+        if (isDark) {
+          root.removeAttribute('data-theme');
+          localStorage.setItem('theme', 'light');
+        } else {
+          root.setAttribute('data-theme', 'dark');
+          localStorage.setItem('theme', 'dark');
+        }
+      });
+    </script>
   </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -309,6 +309,42 @@ p:last-child {
   }
 }
 
+/* Manual dark mode override */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-text: #e5e7eb;
+  --color-text-muted: #9ca3af;
+  --color-bg: #0b1220;
+  --color-border: #1f2937;
+  --color-accent: #60a5fa;
+  --color-accent-hover: #93c5fd;
+}
+
+[data-theme="dark"] .md code {
+  background: #111827;
+}
+
+[data-theme="dark"] .grid2 {
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.6);
+}
+
+[data-theme="dark"] .badge {
+  background: #0f172a;
+  border-color: #1f2937;
+}
+
+[data-theme="dark"] .badge--hot {
+  color: #fecaca;
+  background: #3f1a1a;
+  border-color: #7f1d1d;
+}
+
+[data-theme="dark"] .badge--long {
+  color: #a7f3d0;
+  background: #0f2c24;
+  border-color: #115e59;
+}
+
 /* Auto dark mode based on user's system preference */
 @media (prefers-color-scheme: dark) {
   :root {


### PR DESCRIPTION
## Summary
- add theme toggle button on index and pagination pages
- implement script to persist theme preference using `data-theme`
- support manual dark mode overrides in global styles

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689744cdd378833385e7331b17d42ac5