### PR TITLE
chore: remove Jina API key configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
 # optional: used by summarize step; if empty, summaries are skipped
 OPENROUTER_API_KEY=
-# optional: used by Jina reader proxy for article text
-JINA_API_KEY=
 
 # defaults for data generation
 SUMMARY_LANG=ru

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - What: Static site that fetches top Hacker News stories, distills article text and comments, and publishes daily/weekly digests.
 - Requires: `bun`.
-- Setup: `cp .env.example .env` and set `OPENROUTER_API_KEY` (optional for summaries) and `JINA_API_KEY` (optional reader).
+- Setup: `cp .env.example .env` and set `OPENROUTER_API_KEY` (optional for summaries). Turndown converts article HTML to Markdown.
 - Generate data: `bun install` then `bun run data:all` (or `make run`).
 - Develop: `bunx astro dev` (or `make dev`).
 - Build/preview: `bunx astro build && bunx astro preview` (or `make build`/`make preview`).

--- a/config/env.ts
+++ b/config/env.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 const EnvSchema = z.object({
   OPENROUTER_API_KEY: z.string().optional(),
-  JINA_API_KEY: z.string().optional(),
   SUMMARY_LANG: z.enum(["ru", "en"]).default("ru"),
   TOP_N: z.coerce.number().int().min(1).max(500).default(40),
   MAX_COMMENTS_PER_STORY: z.coerce.number().int().min(1).max(5000).default(40),


### PR DESCRIPTION
## Summary
- drop `JINA_API_KEY` from env schema and sample `.env`
- update README setup instructions and note Turndown for HTML-to-Markdown conversion

## Testing
- `bun test`
- `bunx tsc --noEmit` *(fails: Cannot find module './components/Image.astro', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689881b9eff88333a61c8bbec98fc384