### PR TITLE
Test article Markdown conversion and caching

### DIFF
--- a/scripts/summarize.mts
+++ b/scripts/summarize.mts
@@ -182,7 +182,7 @@ export async function summarizeComments(
   return { id: storyId, lang: SUMMARY_LANG, summary, sampleComments: sampleIds };
 }
 
-async function getOrFetchArticleMarkdown(services: Services, story: NormalizedStory): Promise<string | null> {
+export async function getOrFetchArticleMarkdown(services: Services, story: NormalizedStory): Promise<string | null> {
   if (!story.url) {
     log.warn("summarize/article", "Story has no URL; cannot fetch article", { id: story.id });
     return null;

--- a/tests/summarize.fetchArticle.test.ts
+++ b/tests/summarize.fetchArticle.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "bun:test";
+import { getOrFetchArticleMarkdown } from "../scripts/summarize.mts";
+import { pathFor } from "../config/paths.ts";
+import htmlToMd from "../utils/htmlToMd.ts";
+import type { HttpClient } from "../utils/http-client.ts";
+import { rmSync, existsSync } from "fs";
+
+describe("summarize.getOrFetchArticleMarkdown", () => {
+  test("fetches, converts, caches and avoids refetch", async () => {
+    const story = {
+      id: 99999901,
+      title: "t",
+      url: "https://example.com",
+      by: "u",
+      timeISO: new Date().toISOString(),
+      commentIds: [] as number[],
+    };
+    const path = pathFor.articleMd(story.id);
+    // ensure clean slate
+    rmSync(path, { force: true });
+
+    const sampleHtml = "<h1>Hello</h1><p>World</p>";
+    const http: Pick<HttpClient, "text"> & { calls: number } = {
+      calls: 0,
+      text: async (_url: string) => {
+        http.calls++;
+        return sampleHtml;
+      },
+    };
+    const services = {
+      fetchArticleMarkdown: async (url: string) => {
+        const html = await http.text(url);
+        return htmlToMd(html);
+      },
+    } as any;
+
+    const md1 = await getOrFetchArticleMarkdown(services, story as any);
+    expect(md1).toContain("# Hello");
+    expect(http.calls).toBe(1);
+    expect(existsSync(path)).toBe(true);
+
+    const md2 = await getOrFetchArticleMarkdown(services, story as any);
+    expect(md2).toBe(md1);
+    expect(http.calls).toBe(1); // no refetch
+
+    rmSync(path, { force: true });
+  });
+});
+

--- a/tests/utils.htmlToMd.test.ts
+++ b/tests/utils.htmlToMd.test.ts
@@ -17,6 +17,23 @@ describe("utils/htmlToMd", () => {
     expect(md).toContain("console.log('hi')");
   });
 
+  test("handles headings, links, lists and ignores scripts/styles", () => {
+    const html = `
+      <h1>Main</h1>
+      <p>Visit <a href="https://example.com">link</a></p>
+      <ul><li>One</li><li>Two</li></ul>
+      <script>console.log('x')</script>
+      <style>p { color: red; }</style>
+    `;
+    const md = htmlToMd(html);
+    expect(md).toContain("# Main");
+    expect(md).toContain("[link](https://example.com)");
+    expect(md).toContain("*   One");
+    expect(md).toContain("*   Two");
+    expect(md).not.toContain("console.log");
+    expect(md).not.toContain("color: red");
+  });
+
   test("default export works", () => {
     const html = "<p>Hello</p>";
     expect(htmlToMdDefault(html)).toBe("Hello");

--- a/utils/htmlToMd.ts
+++ b/utils/htmlToMd.ts
@@ -5,6 +5,8 @@ const turndown = new TurndownService({
   codeBlockStyle: 'fenced',
 });
 
+turndown.remove(["script", "style"]);
+
 export function htmlToMd(html: string): string {
   if (!html) return '';
   return turndown.turndown(html);


### PR DESCRIPTION
## Summary
- ensure html-to-markdown conversion strips scripts and styles and verify headings, links, and lists
- export and test `getOrFetchArticleMarkdown` for caching using a mocked HttpClient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689881f6c7c08333a7ab0836387120b4