### PR TITLE
Rebase before hourly data push

### DIFF
--- a/.github/workflows/hourly-build.yml
+++ b/.github/workflows/hourly-build.yml
@@ -52,8 +52,11 @@ jobs:
           fi
 
           # Always create a new commit; never amend/force-push
-          git commit -m "$MSG" || echo "no changes"
-          git push || true
+          git commit -m "$MSG"
+
+          # Rebase on top of the latest remote and retry the push if needed
+          git pull --rebase origin main
+          git push
 
       - name: Build
         env:


### PR DESCRIPTION
## Summary
- Rebase on `origin/main` before pushing generated data in the hourly build workflow to avoid rejected pushes

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_689888c297ac83339b95a24479e9bb8f