### PR TITLE
feat: add shared layout and refactor pages

### DIFF
--- a/src/components/HeadMeta.astro
+++ b/src/components/HeadMeta.astro
@@ -1,0 +1,21 @@
+---
+export interface Props {
+  title: string;
+  description: string;
+  ogType?: 'website' | 'article';
+}
+const { title, description, ogType = 'website' } = Astro.props as Props;
+---
+<meta charset="utf-8" />
+<title>{title}</title>
+<meta name="description" content={description} />
+<meta name="robots" content="index,follow" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:url" content={Astro.url.href} />
+<meta property="og:site_name" content="Hacker News Digest" />
+<meta property="og:type" content={ogType} />
+<meta name="color-scheme" content="light dark" />
+<meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
+<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b1220" />

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -1,0 +1,97 @@
+---
+import '../styles/global.css';
+import HeadMeta from './HeadMeta.astro';
+import { PATHS } from '@config/paths';
+import { loadAggregated } from '@utils/load-aggregated';
+import { isoWeekKey } from '@utils/date-keys';
+
+export interface Props {
+  lang: 'en' | 'ru';
+  title: string;
+  description: string;
+  ogType?: 'website' | 'article';
+  breadcrumbs?: { label: string; href: string }[];
+}
+
+const {
+  lang,
+  title,
+  description,
+  ogType = 'website',
+  breadcrumbs,
+} = Astro.props as Props;
+
+const i18n = {
+  ru: {
+    navDaily: 'За день',
+    nav3d: 'За три дня',
+    navWeekly: 'За неделю',
+    navTags: 'Теги',
+    navSearch: 'Поиск',
+  },
+  en: {
+    navDaily: 'Daily',
+    nav3d: '3 days',
+    navWeekly: 'Weekly',
+    navTags: 'Tags',
+    navSearch: 'Search',
+  },
+} as const;
+const t = i18n[lang];
+
+const { items } = loadAggregated(PATHS.aggregated);
+const firstItem = items[0];
+const latestDate = firstItem?.timeISO
+  ? new Date(firstItem.timeISO).toISOString().slice(0, 10)
+  : new Date().toISOString().slice(0, 10);
+const currentWeek = isoWeekKey(new Date().toISOString());
+---
+<html lang={lang}>
+  <head>
+    <HeadMeta title={title} description={description} ogType={ogType} />
+    <slot name="head" />
+  </head>
+  <body>
+    <header>
+      <div class="header-top">
+        <h1><a href="/">Hacker News Digest</a></h1>
+        <nav class="header-nav" aria-label="Site navigation">
+          <a href={`/daily/${latestDate}/`}>{t.navDaily}</a>
+          <a href={`/3d/${latestDate}/`}>{t.nav3d}</a>
+          <a href={`/weekly/${currentWeek}/`}>{t.navWeekly}</a>
+          <a href="/tags/">{t.navTags}</a>
+          <a href="/search/">{t.navSearch}</a>
+        </nav>
+        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+      </div>
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          {breadcrumbs.map((b, i) => (
+            <span><a href={b.href}>{b.label}</a>{i < breadcrumbs.length - 1 && ' / '}</span>
+          ))}
+        </nav>
+      )}
+    </header>
+    <main>
+      <slot />
+    </main>
+    <script>
+      const root = document.documentElement;
+      const btn = document.getElementById('theme-toggle');
+      if (localStorage.getItem('theme') === 'dark') {
+        root.setAttribute('data-theme', 'dark');
+      }
+      btn?.addEventListener('click', () => {
+        const isDark = root.getAttribute('data-theme') === 'dark';
+        if (isDark) {
+          root.removeAttribute('data-theme');
+          localStorage.setItem('theme', 'light');
+        } else {
+          root.setAttribute('data-theme', 'dark');
+          localStorage.setItem('theme', 'dark');
+        }
+      });
+    </script>
+    <script is:inline src="/js/keyboard-nav.js"></script>
+  </body>
+</html>

--- a/src/pages/3d/[date].astro
+++ b/src/pages/3d/[date].astro
@@ -1,6 +1,6 @@
 ---
 import StorySection from '../../components/StorySection.astro';
-import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
 import { LANG } from '@config/lang';
 import { PATHS } from '@config/paths';
 import { DailyGroupFileSchema, type AggregatedItem } from '@config/schemas';
@@ -52,42 +52,24 @@ const i18n = {
   ru: {
     title: 'За три дня',
     noData: 'Нет данных для выбранного периода.',
+    posts: 'Постов',
   },
   en: {
     title: 'Last 3 days',
     noData: 'No data for the selected period.',
+    posts: 'Posts',
   },
 } as const;
 const t = i18n[lang as 'ru' | 'en'];
 const pageTitle = `${t.title}: ${displayStartDate} — ${displayEndDate} — Hacker News Digest`;
 const description = `Hacker News Digest for ${displayStartDate} — ${displayEndDate}. ${triItems.length} posts.`;
 ---
-<html lang={lang}>
-  <head>
-    <meta charset="utf-8" />
-    <title>{pageTitle}</title>
-    <meta name="description" content={description} />
-    <meta name="robots" content="index,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={Astro.url.href} />
-    <meta property="og:site_name" content="Hacker News Digest" />
-    <meta property="og:type" content="website" />
-  </head>
-  <body>
-    <header>
-      <h1><a href="/">Hacker News Digest</a></h1>
-      <p class="meta">{t.title}: {displayStartDate} — {displayEndDate}</p>
-      <p class="meta">Постов: {triItems.length}</p>
-    </header>
-    <main>
-      {triItems.length === 0 ? (
-        <p class="meta">{t.noData}</p>
-      ) : (
-        triItems.map((it: AggregatedItem) => <StorySection item={it} tagCounts={tagCountsObj} />)
-      )}
-    </main>
-    <script is:inline src="/js/keyboard-nav.js"></script>
-  </body>
-  </html>
+<Layout lang={lang} title={pageTitle} description={description}>
+  <p class="meta">{t.title}: {displayStartDate} — {displayEndDate}</p>
+  <p class="meta">{t.posts}: {triItems.length}</p>
+  {triItems.length === 0 ? (
+    <p class="meta">{t.noData}</p>
+  ) : (
+    triItems.map((it: AggregatedItem) => <StorySection item={it} tagCounts={tagCountsObj} />)
+  )}
+</Layout>

--- a/src/pages/daily/[date].astro
+++ b/src/pages/daily/[date].astro
@@ -1,6 +1,6 @@
 ---
 import StorySection from '../../components/StorySection.astro';
-import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
 import { LANG } from '@config/lang';
 import { PATHS } from '@config/paths';
 import { DailyGroupFileSchema, type AggregatedItem } from '@config/schemas';
@@ -55,32 +55,12 @@ const t = i18n[lang as 'ru' | 'en'];
 const pageTitle = `${t.title}: ${displayDate} — Hacker News Digest`;
 const description = `Hacker News Digest for ${displayDate}. ${dayItems.length} ${t.posts}.`;
 ---
-<html lang={lang}>
-  <head>
-    <meta charset="utf-8" />
-    <title>{pageTitle}</title>
-    <meta name="description" content={description} />
-    <meta name="robots" content="index,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={Astro.url.href} />
-    <meta property="og:site_name" content="Hacker News Digest" />
-    <meta property="og:type" content="website" />
-  </head>
-  <body>
-    <header>
-      <h1><a href="/">Hacker News Digest</a></h1>
-      <p class="meta">{t.title}: {displayDate}</p>
-      <p class="meta">Постов: {dayItems.length}</p>
-    </header>
-    <main>
-      {dayItems.length === 0 ? (
-        <p class="meta">{t.noData}</p>
-      ) : (
-        dayItems.map((it) => <StorySection item={it} tagCounts={tagCountsObj} />)
-      )}
-    </main>
-    <script is:inline src="/js/keyboard-nav.js"></script>
-  </body>
-  </html>
+<Layout lang={lang} title={pageTitle} description={description}>
+  <p class="meta">{t.title}: {displayDate}</p>
+  <p class="meta">{t.posts}: {dayItems.length}</p>
+  {dayItems.length === 0 ? (
+    <p class="meta">{t.noData}</p>
+  ) : (
+    dayItems.map((it: AggregatedItem) => <StorySection item={it} tagCounts={tagCountsObj} />)
+  )}
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,7 @@
 ---
 import StorySection from "../components/StorySection.astro";
-import "../styles/global.css";
+import Layout from "../components/Layout.astro";
 import { LANG } from "@config/lang";
-import { isoWeekKey } from "@utils/date-keys";
 import { formatDateHuman } from "@utils/date";
 import type { AggregatedItem } from "@config/schemas";
 import { loadAggregated } from "@utils/load-aggregated";
@@ -27,15 +26,6 @@ function pageHref(n: number): string {
   return path.endsWith("/") ? path : `${path}/`;
 }
 
-// Generate date for navigation links based on latest data
-const firstItem = allItems[0];
-const latestDate = firstItem?.timeISO
-  ? new Date(firstItem.timeISO).toISOString().slice(0, 10)
-  : new Date().toISOString().slice(0, 10);
-
-// Generate current week for weekly link (consistent with isoWeekKey format)
-const currentWeek = isoWeekKey(new Date().toISOString());
-
 const i18n = {
   ru: {
     updated: "Обновлено",
@@ -43,11 +33,6 @@ const i18n = {
     noData: "Нет данных для отображения. Попробуйте позже.",
     page: "Страница",
     next: "Вперёд »",
-    navDaily: "За день",
-    nav3d: "За три дня",
-    navWeekly: "За неделю",
-    navTags: "Теги",
-    navSearch: "Поиск",
   },
   en: {
     updated: "Updated",
@@ -55,89 +40,32 @@ const i18n = {
     noData: "No data to display. Please try again later.",
     page: "Page",
     next: "Next »",
-    navDaily: "Daily",
-    nav3d: "3 days",
-    navWeekly: "Weekly",
-    navTags: "Tags",
-    navSearch: "Search",
   },
 };
 const t = i18n[lang];
 const pageTitle = `Hacker News Digest — ${t.page} 1/${totalPages}`;
 const description = `${t.stories}: ${allItems.length}. ${t.updated}: ${updatedPretty}.`;
 ---
-
-<html lang={lang}>
-  <head>
-    <meta charset="utf-8" />
-    <title>{pageTitle}</title>
-    <meta name="description" content={description} />
-    <meta name="robots" content="index,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={Astro.url.href} />
-    <meta property="og:site_name" content="Hacker News Digest" />
-    <meta property="og:type" content="website" />
-    <meta name="color-scheme" content="light dark" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b1220" />
-  </head>
-  <body>
-    <header>
-      <div class="header-top">
-        <h1><a href="/">Hacker News Digest</a></h1>
-        <nav class="header-nav" aria-label="Site navigation">
-          <a href={`/daily/${latestDate}/`}>{t.navDaily}</a>
-          <a href={`/3d/${latestDate}/`}>{t.nav3d}</a>
-          <a href={`/weekly/${currentWeek}/`}>{t.navWeekly}</a>
-          <a href="/tags/">{t.navTags}</a>
-          <a href="/search/">{t.navSearch}</a>
-        </nav>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
-      </div>
-      <p class="meta">{t.updated}: {updatedPretty}</p>
-      <p class="meta">{t.stories}: {allItems.length} • {t.page} 1/{totalPages}</p>
-    </header>
-    <main>
-      {
-        allItems.length === 0 ? (
-          <p class="meta">{t.noData}</p>
-        ) : (
-          pageItems.map((it: AggregatedItem) => <StorySection item={it} tagCounts={tagCountsObj} />)
-        )
-      }
-      {
-        allItems.length > 0 && totalPages > 1 && (
-          <nav class="pagination" aria-label="Pagination">
-            <span>
-              {t.page} 1 / {totalPages}
-            </span>
-            <a href={pageHref(2)} rel="next">
-              {t.next}
-            </a>
-          </nav>
-        )
-      }
-    </main>
-    <script>
-      const root = document.documentElement;
-      const btn = document.getElementById("theme-toggle");
-      if (localStorage.getItem("theme") === "dark") {
-        root.setAttribute("data-theme", "dark");
-      }
-      btn?.addEventListener("click", () => {
-        const isDark = root.getAttribute("data-theme") === "dark";
-        if (isDark) {
-          root.removeAttribute("data-theme");
-          localStorage.setItem("theme", "light");
-        } else {
-          root.setAttribute("data-theme", "dark");
-          localStorage.setItem("theme", "dark");
-        }
-      });
-    </script>
-
-    <script is:inline src="/js/keyboard-nav.js"></script>
-  </body>
-</html>
+<Layout lang={lang} title={pageTitle} description={description}>
+  <p class="meta">{t.updated}: {updatedPretty}</p>
+  <p class="meta">{t.stories}: {allItems.length} • {t.page} 1/{totalPages}</p>
+  {
+    allItems.length === 0 ? (
+      <p class="meta">{t.noData}</p>
+    ) : (
+      pageItems.map((it: AggregatedItem) => <StorySection item={it} tagCounts={tagCountsObj} />)
+    )
+  }
+  {
+    allItems.length > 0 && totalPages > 1 && (
+      <nav class="pagination" aria-label="Pagination">
+        <span>
+          {t.page} 1 / {totalPages}
+        </span>
+        <a href={pageHref(2)} rel="next">
+          {t.next}
+        </a>
+      </nav>
+    )
+  }
+</Layout>

--- a/src/pages/item/[id].astro
+++ b/src/pages/item/[id].astro
@@ -1,5 +1,5 @@
 ---
-// src/pages/item/[id].astro
+import Layout from "../../components/Layout.astro";
 import { LANG } from "@config/lang";
 import { PATHS } from "@config/paths";
 import type { AggregatedItem } from "@config/schemas";
@@ -8,7 +8,6 @@ import { loadAggregated } from "@utils/load-aggregated";
 import { mdToHtml } from "@utils/md-to-html";
 import type { GetStaticPaths } from "astro";
 import { existsSync, readFileSync } from "node:fs";
-import "../../styles/global.css";
 import { TAG_MIN_COUNT } from "@config/constants";
 import { countTags } from "@utils/tag-counts";
 
@@ -63,47 +62,29 @@ const i18n = {
 const t = i18n[lang];
 const commentsLabel = typeof item.commentsCount === "number" ? ` (${item.commentsCount})` : "";
 ---
-
-<html lang={lang}>
-  <head>
-    <meta charset="utf-8" />
-    <title>{item.title}</title>
-    <meta name="description" content={description} />
-    <meta name="robots" content="index,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content={item.title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={Astro.url.href} />
-    <meta property="og:site_name" content="Hacker News Digest" />
-    <meta property="og:type" content="article" />
+<Layout lang={lang} title={item.title} description={description} ogType="article">
+  <Fragment slot="head">
     <link rel="canonical" href={hnUrl} />
-  </head>
-  <body>
-    <header>
-      <h1><a href="/">Hacker News Digest</a></h1>
-      <p class="meta">
-        {datePretty} • {item.domain ?? "news.ycombinator.com"} • ⭐ {item.score ?? 0} • 💬 {item.commentsCount ?? 0}
-      </p>
-      <p class="meta"><a href={item.url ?? hnUrl} rel="noopener noreferrer">Original</a> • <a href={hnUrl}>HN</a></p>
-      {tags.length > 0 && (
-        <p class="meta tags">
-          {tags.map((tag) => <a href={tagHref(tag)} class="tag">#{tag}</a>)}
-        </p>
-      )}
-    </header>
-    <main>
-      <section class="grid2">
-        <div class="card">
-          <h2 class="title">{item.title}</h2>
-          {postHtml ? <div class="md" set:html={postHtml} /> : <p class="meta">No post summary.</p>}
-        </div>
-        <aside class="card">
-          <h3 class="title">
-            <a href={hnUrl} target="_blank" rel="noopener noreferrer nofollow">{t.comments}{commentsLabel}</a>
-          </h3>
-          {commentsHtml ? <div class="md" set:html={commentsHtml} /> : <p class="meta">No comments summary.</p>}
-        </aside>
-      </section>
-    </main>
-  </body>
-</html>
+  </Fragment>
+  <p class="meta">
+    {datePretty} • {item.domain ?? "news.ycombinator.com"} • ⭐ {item.score ?? 0} • 💬 {item.commentsCount ?? 0}
+  </p>
+  <p class="meta"><a href={item.url ?? hnUrl} rel="noopener noreferrer">Original</a> • <a href={hnUrl}>HN</a></p>
+  {tags.length > 0 && (
+    <p class="meta tags">
+      {tags.map((tag) => <a href={tagHref(tag)} class="tag">#{tag}</a>)}
+    </p>
+  )}
+  <section class="grid2">
+    <div class="card">
+      <h2 class="title">{item.title}</h2>
+      {postHtml ? <div class="md" set:html={postHtml} /> : <p class="meta">No post summary.</p>}
+    </div>
+    <aside class="card">
+      <h3 class="title">
+        <a href={hnUrl} target="_blank" rel="noopener noreferrer nofollow">{t.comments}{commentsLabel}</a>
+      </h3>
+      {commentsHtml ? <div class="md" set:html={commentsHtml} /> : <p class="meta">No comments summary.</p>}
+    </aside>
+  </section>
+</Layout>

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -1,6 +1,6 @@
 ---
 import StorySection from "../../components/StorySection.astro";
-import "../../styles/global.css";
+import Layout from "../../components/Layout.astro";
 import { LANG } from "@config/lang";
 import { PATHS } from "@config/paths";
 import { formatDateHuman } from "@utils/date";
@@ -37,16 +37,6 @@ function pageHref(n: number): string {
   return path.endsWith("/") ? path : `${path}/`;
 }
 
-// Generate date for navigation links based on latest data
-const firstItem = allItems[0];
-const latestDate = firstItem?.timeISO
-  ? new Date(firstItem.timeISO).toISOString().slice(0, 10)
-  : new Date().toISOString().slice(0, 10);
-
-// Generate current week for weekly link (consistent with isoWeekKey format)
-import { isoWeekKey } from "@utils/date-keys";
-const currentWeek = isoWeekKey(new Date().toISOString());
-
 const i18n = {
   ru: {
     updated: "Обновлено",
@@ -55,11 +45,6 @@ const i18n = {
     page: "Страница",
     prev: "« Назад",
     next: "Вперёд »",
-    navDaily: "За день",
-    nav3d: "За три дня",
-    navWeekly: "За неделю",
-    navTags: "Теги",
-    navSearch: "Поиск",
   },
   en: {
     updated: "Updated",
@@ -68,100 +53,43 @@ const i18n = {
     page: "Page",
     prev: "« Prev",
     next: "Next »",
-    navDaily: "Daily",
-    nav3d: "3 days",
-    navWeekly: "Weekly",
-    navTags: "Tags",
-    navSearch: "Search",
   },
 };
 const t = i18n[lang];
 const pageTitle = `Hacker News Digest — ${t.page} ${currentPage}/${totalPages}`;
 const description = `${t.page} ${currentPage}/${totalPages} of Hacker News Digest. ${t.updated}: ${updatedPretty}.`;
 ---
-
-<html lang={lang}>
-  <head>
-    <meta charset="utf-8" />
-    <title>{pageTitle}</title>
-    <meta name="description" content={description} />
-    <meta name="robots" content="index,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={Astro.url.href} />
-    <meta property="og:site_name" content="Hacker News Digest" />
-    <meta property="og:type" content="website" />
-    <meta name="color-scheme" content="light dark" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b1220" />
-  </head>
-  <body>
-    <header>
-      <div class="header-top">
-        <h1><a href="/">Hacker News Digest</a></h1>
-        <nav class="header-nav" aria-label="Site navigation">
-          <a href={`/daily/${latestDate}/`}>{t.navDaily}</a>
-          <a href={`/3d/${latestDate}/`}>{t.nav3d}</a>
-          <a href={`/weekly/${currentWeek}/`}>{t.navWeekly}</a>
-          <a href="/tags/">{t.navTags}</a>
-          <a href="/search/">{t.navSearch}</a>
-        </nav>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
-      </div>
-      <p class="meta">{t.updated}: {updatedPretty}</p>
-      <p class="meta">{t.stories}: {allItems.length} • {t.page} {currentPage}/{totalPages}</p>
-    </header>
-    <main>
-      {
-        allItems.length === 0 ? (
-          <p class="meta">{t.noData}</p>
+<Layout lang={lang} title={pageTitle} description={description}>
+  <p class="meta">{t.updated}: {updatedPretty}</p>
+  <p class="meta">{t.stories}: {allItems.length} • {t.page} {currentPage}/{totalPages}</p>
+  {
+    allItems.length === 0 ? (
+      <p class="meta">{t.noData}</p>
+    ) : (
+      pageItems.map((it: AggregatedItem) => <StorySection item={it} tagCounts={tagCountsObj} />)
+    )
+  }
+  {
+    allItems.length > 0 && (
+      <nav class="pagination" aria-label="Pagination">
+        {currentPage > 1 ? (
+          <a href={pageHref(currentPage - 1)} rel="prev">
+            {t.prev}
+          </a>
         ) : (
-          pageItems.map((it: AggregatedItem) => <StorySection item={it} tagCounts={tagCountsObj} />)
-        )
-      }
-      {
-        allItems.length > 0 && (
-          <nav class="pagination" aria-label="Pagination">
-            {currentPage > 1 ? (
-              <a href={pageHref(currentPage - 1)} rel="prev">
-                {t.prev}
-              </a>
-            ) : (
-              <span />
-            )}
-            <span>
-              {t.page} {currentPage} / {totalPages}
-            </span>
-            {currentPage < totalPages ? (
-              <a href={pageHref(currentPage + 1)} rel="next">
-                {t.next}
-              </a>
-            ) : (
-              <span />
-            )}
-          </nav>
-        )
-      }
-    </main>
-    <script>
-      const root = document.documentElement;
-      const btn = document.getElementById("theme-toggle");
-      if (localStorage.getItem("theme") === "dark") {
-        root.setAttribute("data-theme", "dark");
-      }
-      btn?.addEventListener("click", () => {
-        const isDark = root.getAttribute("data-theme") === "dark";
-        if (isDark) {
-          root.removeAttribute("data-theme");
-          localStorage.setItem("theme", "light");
-        } else {
-          root.setAttribute("data-theme", "dark");
-          localStorage.setItem("theme", "dark");
-        }
-      });
-    </script>
-
-    <script is:inline src="/js/keyboard-nav.js"></script>
-  </body>
-</html>
+          <span />
+        )}
+        <span>
+          {t.page} {currentPage} / {totalPages}
+        </span>
+        {currentPage < totalPages ? (
+          <a href={pageHref(currentPage + 1)} rel="next">
+            {t.next}
+          </a>
+        ) : (
+          <span />
+        )}
+      </nav>
+    )
+  }
+</Layout>

--- a/src/pages/tag/[tag].astro
+++ b/src/pages/tag/[tag].astro
@@ -1,6 +1,6 @@
 ---
 import StorySection from '../../components/StorySection.astro';
-import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
 import { LANG } from '@config/lang';
 import { PATHS } from '@config/paths';
 import type { AggregatedItem } from '@config/schemas';
@@ -41,32 +41,12 @@ const t = i18n[lang as 'ru' | 'en'];
 const pageTitle = `${t.title}: #${tag} — Hacker News Digest`;
 const description = `Hacker News Digest for tag #${tag}. ${filteredItems.length} ${t.posts}.`;
 ---
-<html lang={lang}>
-  <head>
-    <meta charset="utf-8" />
-    <title>{pageTitle}</title>
-    <meta name="description" content={description} />
-    <meta name="robots" content="index,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={Astro.url.href} />
-    <meta property="og:site_name" content="Hacker News Digest" />
-    <meta property="og:type" content="website" />
-  </head>
-  <body>
-    <header>
-      <h1><a href="/">Hacker News Digest</a></h1>
-      <p class="meta">{t.title}: #{tag}</p>
-      <p class="meta">{t.posts}: {filteredItems.length}</p>
-    </header>
-    <main>
-      {filteredItems.length === 0 ? (
-        <p class="meta">{t.noData}</p>
-      ) : (
-        filteredItems.map((it) => <StorySection item={it} />)
-      )}
-    </main>
-    <script is:inline src="/js/keyboard-nav.js"></script>
-  </body>
-</html>
+<Layout lang={lang} title={pageTitle} description={description}>
+  <p class="meta">{t.title}: #{tag}</p>
+  <p class="meta">{t.posts}: {filteredItems.length}</p>
+  {filteredItems.length === 0 ? (
+    <p class="meta">{t.noData}</p>
+  ) : (
+    filteredItems.map((it) => <StorySection item={it} />)
+  )}
+</Layout>

--- a/src/pages/tags.astro
+++ b/src/pages/tags.astro
@@ -1,5 +1,5 @@
 ---
-import '../styles/global.css';
+import Layout from "../components/Layout.astro";
 import { LANG } from '@config/lang';
 import { PATHS } from '@config/paths';
 import { loadAggregated } from '@utils/load-aggregated';
@@ -62,47 +62,29 @@ const hrefFor = (tag: string, count: number) =>
 const pageTitle = `${t.title} — Hacker News Digest`;
 const description = `${t.description}. ${t.totalTags}: ${sortedTags.length}`;
 ---
-<html lang={lang}>
-  <head>
-    <meta charset="utf-8" />
-    <title>{pageTitle}</title>
-    <meta name="description" content={description} />
-    <meta name="robots" content="index,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={Astro.url.href} />
-    <meta property="og:site_name" content="Hacker News Digest" />
-    <meta property="og:type" content="website" />
-  </head>
-  <body>
-    <header>
-      <h1><a href="/">Hacker News Digest</a></h1>
-      <p class="meta">{t.title}</p>
-      <p class="meta">{t.totalTags}: {sortedTags.length}</p>
-    </header>
-    <main>
-      {sortedTags.length === 0 ? (
-        <p class="meta">Нет тегов для отображения.</p>
-      ) : (
-        <div class="tags-grid">
-          {sortedTags.map(([tag, count]) => (
-            <a href={hrefFor(tag, count)} class="tag-card" data-count={count}>
-              <span class="tag-name">#{tag}</span>
-              <span class="tag-count">{count} {getPostsLabel(count)}</span>
-            </a>
-          ))}
-        </div>
-      )}
-    </main>
-    <style>
+<Layout lang={lang} title={pageTitle} description={description}>
+  <p class="meta">{t.title}</p>
+  <p class="meta">{t.totalTags}: {sortedTags.length}</p>
+  {sortedTags.length === 0 ? (
+    <p class="meta">Нет тегов для отображения.</p>
+  ) : (
+    <div class="tags-grid">
+      {sortedTags.map(([tag, count]) => (
+        <a href={hrefFor(tag, count)} class="tag-card" data-count={count}>
+          <span class="tag-name">#{tag}</span>
+          <span class="tag-count">{count} {getPostsLabel(count)}</span>
+        </a>
+      ))}
+    </div>
+  )}
+  <style>
       .tags-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: var(--space-sm);
         margin-top: var(--space-md);
       }
-      
+
       .tag-card {
         display: flex;
         flex-direction: column;
@@ -114,24 +96,24 @@ const description = `${t.description}. ${t.totalTags}: ${sortedTags.length}`;
         color: var(--color-text);
         transition: all 0.2s ease;
       }
-      
+
       .tag-card:hover {
         background: var(--color-border);
         transform: translateY(-1px);
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
       }
-      
+
       .tag-name {
         font-weight: 600;
         color: var(--color-accent);
         margin-bottom: var(--space-xs);
       }
-      
+
       .tag-count {
         font-size: var(--font-size-xs);
         color: var(--color-text-muted);
       }
-      
+
       @media (max-width: 768px) {
         .tags-grid {
           grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
@@ -139,5 +121,4 @@ const description = `${t.description}. ${t.totalTags}: ${sortedTags.length}`;
         }
       }
     </style>
-  </body>
-</html>
+</Layout>

--- a/src/pages/weekly/[week].astro
+++ b/src/pages/weekly/[week].astro
@@ -1,6 +1,6 @@
 ---
 import StorySection from '../../components/StorySection.astro';
-import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
 import { LANG } from '@config/lang';
 import { PATHS } from '@config/paths';
 import { WeeklyGroupFileSchema, type AggregatedItem } from '@config/schemas';
@@ -42,42 +42,24 @@ const i18n = {
   ru: {
     title: 'По неделям',
     noData: 'Нет данных для выбранной недели.',
+    posts: 'Постов',
   },
   en: {
     title: 'Weekly',
     noData: 'No data for the selected week.',
+    posts: 'Posts',
   }
 };
 const t = i18n[lang];
 const pageTitle = `${t.title}: ${displayWeek} — Hacker News Digest`;
 const description = `Weekly Hacker News Digest for ${displayWeek}. ${weekItems.length} posts.`;
 ---
-<html lang={lang}>
-  <head>
-    <meta charset="utf-8" />
-    <title>{pageTitle}</title>
-    <meta name="description" content={description} />
-    <meta name="robots" content="index,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content={Astro.url.href} />
-    <meta property="og:site_name" content="Hacker News Digest" />
-    <meta property="og:type" content="website" />
-  </head>
-  <body>
-    <header>
-      <h1><a href="/">Hacker News Digest</a></h1>
-      <p class="meta">{t.title}: {displayWeek}</p>
-      <p class="meta">Posts: {weekItems.length}</p>
-    </header>
-    <main>
-      {weekItems.length === 0 ? (
-        <p class="meta">{t.noData}</p>
-      ) : (
-        weekItems.map((it) => <StorySection item={it} tagCounts={tagCountsObj} />)
-      )}
-    </main>
-    <script is:inline src="/js/keyboard-nav.js"></script>
-  </body>
-  </html>
+<Layout lang={lang} title={pageTitle} description={description}>
+  <p class="meta">{t.title}: {displayWeek}</p>
+  <p class="meta">{t.posts}: {weekItems.length}</p>
+  {weekItems.length === 0 ? (
+    <p class="meta">{t.noData}</p>
+  ) : (
+    weekItems.map((it: AggregatedItem) => <StorySection item={it} tagCounts={tagCountsObj} />)
+  )}
+</Layout>


### PR DESCRIPTION
## Summary
- add Layout component with shared HTML skeleton, nav, and theme toggle
- add HeadMeta helper for meta and OG tags
- refactor main pages to use Layout

## Testing
- `bun run lint` *(fails: Missing return type on function, etc. in existing files)*
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68a71c109b308333a32b905e0094c70d